### PR TITLE
Rename to UNSAFE_componentWillMount

### DIFF
--- a/packages/ext-react/src/renderWhenReady.js
+++ b/packages/ext-react/src/renderWhenReady.js
@@ -19,7 +19,7 @@ export default function renderWhenReady(Component) {
       }
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       if (!this.state.ready) {
         launchQueue.push(this);
       }


### PR DESCRIPTION
Just a temporary fix.
See: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html