### PR TITLE
Removed react from depencencies

### DIFF
--- a/packages/ext-react-modern/package.json
+++ b/packages/ext-react-modern/package.json
@@ -32,9 +32,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@sencha/ext-web-components-modern": "~7.2.0",
-    "fs-extra": "~8.1.0",
-    "react": "~16.13.0",
-    "react-dom": "~16.13.0"
+    "fs-extra": "~8.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",


### PR DESCRIPTION
It causes react to be installed twice, see the answer on https://stackoverflow.com/questions/30451556
I removed it and afterwards, it worked. Before there were "invalid hook call" errors!
It looks drastical but actually, you already specify the react dependencies in the peerDependencies list, so removing it from the dependencies list is just compliancing with the standard.